### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/theme.fish
+++ b/theme.fish
@@ -136,7 +136,7 @@ function theme -d "quick theme switcher"
           . $fish_path/oh-my-fish.fish
 
         else
-          echo (set_color f00)"`$option` is not a theme."(set_color normal) ^&2
+          echo (set_color f00)"`$option` is not a theme."(set_color normal) >&2
           theme --list
           return 1
         end


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618